### PR TITLE
Build PDF through Nix + Deploy to Github Pages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: "Publish"
+on:
+  # Run only when pushing to master branch
+  push:
+    branches:
+      - master
+      - nixify
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Build content (Nix) 🔧
+        run: |
+          nix build -j 4
+      - name: Deploy to gh-pages 🚀
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./result/
+          # cname: yoursite.com

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ DaoFP.ilg
 *.fls
 *.out
 *.pyg
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1666885127,
+        "narHash": "sha256-uXA/3lhLhwOTBMn9a5zJODKqaRT+SuL5cpEmOz2ULoo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0e101dbae756d35a376a5e1faea532608e4a4b9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1667580403,
+        "narHash": "sha256-IoCMTRO51HNtpEzGSdaFprj3E8lH1aut+3tkh/spRTk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f0adf4fcae2aecdd6ade53cb5d4b94d3b7446efd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit self; } {
+      systems = nixpkgs.lib.systems.flakeExposed;
+      perSystem = { self', pkgs, ... }: {
+        packages.default = pkgs.stdenvNoCC.mkDerivation rec {
+          name = "DaoFP.pdf";
+          src = self;
+          buildInputs = [
+            pkgs.coreutils
+            (pkgs.texlive.combine {
+              inherit (pkgs.texlive) scheme-full latex-bin latexmk pygmentex;
+            })
+            pkgs.python37Packages.pygments
+            pkgs.which
+          ];
+          phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+          buildPhase = ''
+            set -e
+            export PATH="${pkgs.lib.makeBinPath buildInputs}";
+            pdflatex -shell-escape DaoFP.tex
+          '';
+          installPhase = ''
+            mkdir -p $out
+            cp DaoFP.pdf $out/
+          '';
+        };
+      };
+    };
+}


### PR DESCRIPTION
- Add a `flake.nix` => can use `nix build` to build the PDF locally.
- This PDF in turn is deployed to Github Pages via Github Actions.

The PDF built in CI for this PR can be found here: https://srid.github.io/DaoFP/DaoFP.pdf

Things to do:

- [ ] Figure out why ToC is missing from the PDF
- [ ] Anything else?

Eventually we can add a package for building the ePub too; https://github.com/BartoszMilewski/DaoFP/issues/9