### PR TITLE
Fix minor typo in DaoFP.tex/Preface

### DIFF
--- a/DaoFP.tex
+++ b/DaoFP.tex
@@ -88,7 +88,7 @@ When faced with a new categorical concepts I would often look them up on Wikiped
 
 There is a lot of folklore knowledge in category theory and in computer science that is nowhere to be found in the literature. It's very difficult to acquire useful intuitions when going through dry definitions and theorems. I tried, as much as possible, to provide the missing intuitions and explain not only the whats but also the whys.
 
-The title of this book alludes to Benjamin Hoff's ``The Tao of Pooh'' and to Robert Pirsig's ``Zen and the Art of Motorcycle Maintenance,'' both being attempts by Westerners to assimilate elements of Easter philosophy. Loosely speaking, the idea is that category theory is to programming as the Dao\footnote{Dao is the more modern spelling of Tao} is to Western philosophy. Many of the definitions of category theory make no sense on first reading but in time you learn to appreciate their deep wisdom. If category theory were to be summarized in one soundbite, it would be: ``Things are defined by their relationship to the Universe.'' 
+The title of this book alludes to Benjamin Hoff's ``The Tao of Pooh'' and to Robert Pirsig's ``Zen and the Art of Motorcycle Maintenance,'' both being attempts by Westerners to assimilate elements of Eastern philosophy. Loosely speaking, the idea is that category theory is to programming as the Dao\footnote{Dao is the more modern spelling of Tao} is to Western philosophy. Many of the definitions of category theory make no sense on first reading but in time you learn to appreciate their deep wisdom. If category theory were to be summarized in one soundbite, it would be: ``Things are defined by their relationship to the Universe.'' 
 
 \subsection{Set theory}
 


### PR DESCRIPTION
Fix minor typo in preface:

`Easter philosophy` -> `Eastern philosophy` (missing terminal `n` in `Eastern`)